### PR TITLE
fix: check existing version before redownloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /node_modules/
-/bin/msedgedriver/
+/bin/msedgedriver

--- a/bin/msedgedriver.js
+++ b/bin/msedgedriver.js
@@ -7,7 +7,7 @@ const execa = require('execa');
 const { getDriverPath } = require('../src');
 
 (async () => {
-  await execa(await getDriverPath(), process.argv.slice(2), {
+  await execa(getDriverPath(), process.argv.slice(2), {
     stdio: 'inherit',
   });
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const arch = os.arch();
 
 const downloadHost = 'https://msedgedriver.azureedge.net';
 
-const driversRoot = path.join(__dirname, '../bin/msedgedriver');
+const driversRoot = path.join(__dirname, '../bin');
 
 function getDownloadName() {
   let firstPart;

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ async function getDriverVersion() {
 
     let ps = await execa(browserCmd, ['--version']);
 
+    // "Microsoft Edge 105.0.1343.53 "
     version = ps.stdout.match(/(?:\d|\.)+/)[0];
 
     console.log(`DETECT_EDGEDRIVER_VERSION=${process.env.DETECT_EDGEDRIVER_VERSION}, detected version ${version}`);

--- a/src/index.js
+++ b/src/index.js
@@ -96,9 +96,26 @@ async function install() {
 
   let driverPath = getDriverPath(driverName);
 
+  let shouldDownload = true;
+
   if (await fs.exists(driverPath)) {
-    console.log(`Found ${driverPath}, not downloading`);
-  } else {
+    let ps = await execa(driverPath, ['--version']);
+
+    // "Microsoft Edge WebDriver 105.0.1343.53 (3a47f00402d579c8ba1fad7e143f9d73831b6765)"
+    let existingVersion = ps.stdout.match(/(?:\d|\.)+/)[0];
+
+    if (existingVersion === version) {
+      console.log(`Found ${driverPath} at version ${existingVersion}, not downloading`);
+
+      shouldDownload = false;
+    } else {
+      console.log(`Found ${driverPath} at different version ${existingVersion}, redownloading`);
+
+      await fs.unlink(driverPath);
+    }
+  }
+
+  if (shouldDownload) {
     await downloadAndExtract({ version, driverName, driverPath });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,6 @@ async function hackLocalBinSymlink() {
 }
 
 module.exports = {
-  driversRoot,
   getDriverPath,
   install,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -84,12 +84,8 @@ function getDriverName() {
   }
 }
 
-async function getDriverPath(version, driverName = getDriverName()) {
-  if (!version) {
-    version = await getDriverVersion();
-  }
-
-  return path.resolve(driversRoot, version, driverName);
+function getDriverPath(driverName = getDriverName()) {
+  return path.resolve(driversRoot, driverName);
 }
 
 async function install() {
@@ -97,7 +93,7 @@ async function install() {
 
   let driverName = getDriverName();
 
-  let driverPath = await getDriverPath(version, driverName);
+  let driverPath = getDriverPath(driverName);
 
   if (await fs.exists(driverPath)) {
     console.log(`Found ${driverPath}, not downloading`);

--- a/test/acceptance/install-msedgedriver-test.js
+++ b/test/acceptance/install-msedgedriver-test.js
@@ -38,8 +38,30 @@ describe(path.basename(installerPath), function() {
     expect(ps.stdout).to.include(oldVersion);
   });
 
+  it('redownloads if different version', async function() {
+    let string = `Found ${driverPath} at different version ${oldVersion}, redownloading`;
+
+    Object.assign(process.env, {
+      EDGEDRIVER_VERSION: oldVersion,
+    });
+
+    let ps = await execa.node(installerPath);
+
+    expect(ps.stdout).to.not.include(string);
+
+    delete process.env.EDGEDRIVER_VERSION;
+
+    ps = await execa.node(installerPath);
+
+    expect(ps.stdout).to.include(string);
+  });
+
   it('doesn\'t redownload same version', async function() {
-    let string = `Found ${driverPath}, not downloading`;
+    let string = `Found ${driverPath} at version ${oldVersion}, not downloading`;
+
+    Object.assign(process.env, {
+      EDGEDRIVER_VERSION: oldVersion,
+    });
 
     let ps = await execa.node(installerPath);
 

--- a/test/acceptance/install-msedgedriver-test.js
+++ b/test/acceptance/install-msedgedriver-test.js
@@ -4,7 +4,7 @@ const { describe, it, setUpObjectReset } = require('../helpers/mocha');
 const { expect } = require('../helpers/chai');
 const execa = require('execa');
 const fs = require('fs').promises;
-const { driversRoot, getDriverPath } = require('../../src');
+const { getDriverPath } = require('../../src');
 const path = require('path');
 
 const installerPath = require.resolve('../../bin/install-msedgedriver');
@@ -16,7 +16,7 @@ describe(path.basename(installerPath), function() {
   setUpObjectReset(process.env);
 
   beforeEach(async function() {
-    await fs.rm(driversRoot, { recursive: true, force: true });
+    await fs.rm(driverPath, { force: true });
   });
 
   it('works', async function() {

--- a/test/acceptance/install-msedgedriver-test.js
+++ b/test/acceptance/install-msedgedriver-test.js
@@ -8,18 +8,15 @@ const { driversRoot, getDriverPath } = require('../../src');
 const path = require('path');
 
 const installerPath = require.resolve('../../bin/install-msedgedriver');
+const driverPath = getDriverPath();
 
 describe(path.basename(installerPath), function() {
   this.timeout(30e3);
 
   setUpObjectReset(process.env);
 
-  let driverPath;
-
   beforeEach(async function() {
     await fs.rm(driversRoot, { recursive: true, force: true });
-
-    driverPath = await getDriverPath();
   });
 
   it('works', async function() {
@@ -34,8 +31,6 @@ describe(path.basename(installerPath), function() {
     Object.assign(process.env, {
       EDGEDRIVER_VERSION: version,
     });
-
-    driverPath = await getDriverPath();
 
     let ps = await execa.node(installerPath);
 
@@ -64,8 +59,6 @@ describe(path.basename(installerPath), function() {
     Object.assign(process.env, {
       DETECT_EDGEDRIVER_VERSION: 'true',
     });
-
-    driverPath = await getDriverPath();
 
     let ps = await execa.node(installerPath);
 

--- a/test/acceptance/install-msedgedriver-test.js
+++ b/test/acceptance/install-msedgedriver-test.js
@@ -7,6 +7,7 @@ const fs = require('fs').promises;
 const { getDriverPath } = require('../../src');
 const path = require('path');
 
+const oldVersion = '102.0.1245.33';
 const installerPath = require.resolve('../../bin/install-msedgedriver');
 const driverPath = getDriverPath();
 
@@ -26,17 +27,15 @@ describe(path.basename(installerPath), function() {
   });
 
   it('can pin the version', async function() {
-    let version = '102.0.1245.33';
-
     Object.assign(process.env, {
-      EDGEDRIVER_VERSION: version,
+      EDGEDRIVER_VERSION: oldVersion,
     });
 
     let ps = await execa.node(installerPath);
 
     expect(driverPath).to.be.a.file();
 
-    expect(ps.stdout).to.include(version);
+    expect(ps.stdout).to.include(oldVersion);
   });
 
   it('doesn\'t redownload same version', async function() {

--- a/test/acceptance/msedgedriver-test.js
+++ b/test/acceptance/msedgedriver-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { describe, it } = require('../helpers/mocha');
+const { describe, it, setUpObjectReset } = require('../helpers/mocha');
 const { expect } = require('../helpers/chai');
 const execa = require('execa');
 const path = require('path');
@@ -11,11 +11,39 @@ const binPath = require.resolve('../../bin/msedgedriver');
 describe(path.basename(binPath), function() {
   this.timeout(30e3);
 
+  setUpObjectReset(process.env);
+
   before(async function() {
     await execa.node(installerPath);
   });
 
   it('works', async function() {
+    let ps = execa.node(binPath);
+
+    let isSuccess = false;
+
+    ps.stdout.on('data', data => {
+      let stdout = data.toString();
+
+      if (stdout.includes('Microsoft Edge WebDriver was started successfully.')) {
+        ps.kill();
+
+        isSuccess = true;
+      }
+    });
+
+    await expect(ps).to.eventually.be.rejectedWith('Command was killed with SIGTERM');
+
+    expect(isSuccess).to.equal(true);
+  });
+
+  it('can find bin even if different version', async function() {
+    let version = '102.0.1245.33';
+
+    Object.assign(process.env, {
+      EDGEDRIVER_VERSION: version,
+    });
+
     let ps = execa.node(binPath);
 
     let isSuccess = false;

--- a/test/acceptance/msedgedriver-test.js
+++ b/test/acceptance/msedgedriver-test.js
@@ -6,7 +6,7 @@ const execa = require('execa');
 const path = require('path');
 
 const installerPath = require.resolve('../../bin/install-msedgedriver');
-const binPath = require.resolve('../../bin/msedgedriver');
+const binPath = require.resolve('../../bin/msedgedriver.js');
 
 describe(path.basename(binPath), function() {
   this.timeout(30e3);

--- a/test/acceptance/msedgedriver-test.js
+++ b/test/acceptance/msedgedriver-test.js
@@ -5,6 +5,7 @@ const { expect } = require('../helpers/chai');
 const execa = require('execa');
 const path = require('path');
 
+const oldVersion = '102.0.1245.33';
 const installerPath = require.resolve('../../bin/install-msedgedriver');
 const binPath = require.resolve('../../bin/msedgedriver.js');
 
@@ -38,10 +39,8 @@ describe(path.basename(binPath), function() {
   });
 
   it('can find bin even if different version', async function() {
-    let version = '102.0.1245.33';
-
     Object.assign(process.env, {
-      EDGEDRIVER_VERSION: version,
+      EDGEDRIVER_VERSION: oldVersion,
     });
 
     let ps = execa.node(binPath);


### PR DESCRIPTION
This is a different way to prevent redownloading. With the prior approach, we kept each bin in its own version folder, but this meant you had to run tests with the same version override that you installed with. With this, you can use the version override forever based on the initial download.