### PR TITLE
Revert "chore: fail-fast: false"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
     needs: lint
 
     strategy:
-      fail-fast: false
       matrix:
         os:
         # edgedriver isn't publishing to these envs
@@ -65,7 +64,6 @@ jobs:
     needs: lint
 
     strategy:
-      fail-fast: false
       matrix:
         os:
         # edgedriver isn't publishing to these envs


### PR DESCRIPTION
Revert this once edgedriver is back to downloading correctly.