### PR TITLE
fix: switch to `msedgedriver.microsoft.com` domain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const { HttpsProxyAgent } = require('https-proxy-agent');
 const platform = os.platform();
 const arch = os.arch();
 
-const downloadHost = 'https://msedgedriver.azureedge.net';
+const downloadHost = 'https://msedgedriver.microsoft.com';
 const latestVersionUrl = `${downloadHost}/LATEST_STABLE`;
 
 const driversRoot = path.join(__dirname, '../bin');

--- a/test/helpers/edge.js
+++ b/test/helpers/edge.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const oldVersion = '102.0.1245.33';
+const oldVersion = '123.0.2420.97';
 
 module.exports = {
   oldVersion,


### PR DESCRIPTION
The domain msedgedriver.azureedge.net appears to be deprecated, and Microsoft has moved the storage location for msedgedriver to `msedgedriver.microsoft.com`

https://msedgedriver.microsoft.com/123.0.2420.97/edgedriver_linux64.zip works so updated the tests to reflect the version. old version in tests might not be in source anymore so tests are failing